### PR TITLE
Fix issue where spectrogram labels get stuck when scrolling (issue #2542)

### DIFF
--- a/src/plugin/spectrogram/index.js
+++ b/src/plugin/spectrogram/index.js
@@ -187,7 +187,7 @@ export default class SpectrogramPlugin {
             const labelsEl = (this.labelsEl = document.createElement('canvas'));
             labelsEl.classList.add('spec-labels');
             this.drawer.style(labelsEl, {
-                position: 'fixed',
+                position: 'absolute',
                 zIndex: 9,
                 height: `${this.height * this.channels}px`,
                 width: `55px`


### PR DESCRIPTION
### Short description of changes:
Change display from 'fixed' to 'absolute' to correct position when scrolling (prevents the spectrogram from scrolling away while leaving the labels 'stuck' on their initial screen position).

To replicate the problem, go to https://wavesurfer-js.org/example/spectrogram/index.html and scroll down.

### Breaking in the external API:
No

### Breaking changes in the internal API:
No

### Todos/Notes:
Tiny change to fix what appears to clearly be a bug / unintended behaviour

### Related Issues and other PRs:
#2542, #1666
